### PR TITLE
Fix Retroid Pocket 5 / Mini led assignment

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8250-retroidpocket-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/sm8250-retroidpocket-common.dtsi
@@ -583,8 +583,8 @@
 
 		ledr_b1: led@1 {
 			reg = <1>;
-			label = "r:b1";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "r:r1";
+			color = <LED_COLOR_ID_RED>;
 		};
 		ledr_g1: led@2 {
 			reg = <2>;
@@ -593,13 +593,13 @@
 		};
 		ledr_r1: led@3 {
 			reg = <3>;
-			label = "r:r1";
-			color = <LED_COLOR_ID_RED>;
+			label = "r:b1";
+			color = <LED_COLOR_ID_BLUE>;
 		};
 		ledr_b2: led@4 {
 			reg = <4>;
-			label = "r:b2";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "r:r2";
+			color = <LED_COLOR_ID_RED>;
 		};
 		ledr_g2: led@5 {
 			reg = <5>;
@@ -608,13 +608,13 @@
 		};
 		ledr_r2: led@6 {
 			reg = <6>;
-			label = "r:r2";
- 			color = <LED_COLOR_ID_RED>;
+			label = "r:b2";
+ 			color = <LED_COLOR_ID_BLUE>;
 		};
 		ledr_b3: led@7 {
 			reg = <7>;
-			label = "r:b3";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "r:r3";
+			color = <LED_COLOR_ID_RED>;
 		};
 		ledr_g3: led@8 {
 			reg = <8>;
@@ -623,13 +623,13 @@
 		};
 		ledr_r3: led@9 {
 			reg = <9>;
-			label = "r:r3";
-			color = <LED_COLOR_ID_RED>;
+			label = "r:b3";
+			color = <LED_COLOR_ID_BLUE>;
 		};
 		ledr_b4: led@10 {
 			reg = <10>;
-			label = "r:b4";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "r:r4";
+			color = <LED_COLOR_ID_RED>;
 		};
 		ledr_g4: led@11 {
 			reg = <11>;
@@ -638,8 +638,8 @@
 		};
 		ledr_r4: led@12 {
 			reg = <12>;
-			label = "r:r4";
-			color = <LED_COLOR_ID_RED>;
+			label = "r:b4";
+			color = <LED_COLOR_ID_BLUE>;
 		};
 	};
 };
@@ -658,8 +658,8 @@
 
 		ledl_b1: led@1 {
 			reg = <1>;
-			label = "l:b1";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "l:r1";
+			color = <LED_COLOR_ID_RED>;
 		};
 		ledl_g1: led@2 {
 			reg = <2>;
@@ -668,13 +668,13 @@
 		};
 		ledl_r1: led@3 {
 			reg = <3>;
-			label = "l:r1";
-			color = <LED_COLOR_ID_RED>;
+			label = "l:b1";
+			color = <LED_COLOR_ID_BLUE>;
 		};
 		ledl_b2: led@4 {
 			reg = <4>;
-			label = "l:b2";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "l:r2";
+			color = <LED_COLOR_ID_RED>;
 		};
 		ledl_g2: led@5 {
 			reg = <5>;
@@ -683,13 +683,13 @@
 		};
 		ledl_r2: led@6 {
 			reg = <6>;
-			label = "l:r2";
-			color = <LED_COLOR_ID_RED>;
+			label = "l:b2";
+			color = <LED_COLOR_ID_BLUE>;
 		};
 		ledl_b3: led@7 {
 			reg = <7>;
-			label = "l:b3";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "l:r3";
+			color = <LED_COLOR_ID_RED>;
 		};
 		ledl_g3: led@8 {
 			reg = <8>;
@@ -698,13 +698,13 @@
 		};
 		ledl_r3: led@9 {
 			reg = <9>;
-			label = "l:r3";
-			color = <LED_COLOR_ID_RED>;
+			label = "l:b3";
+			color = <LED_COLOR_ID_BLUE>;
 		};
 		ledl_b4: led@10 {
 			reg = <10>;
-			label = "l:b4";
-			color = <LED_COLOR_ID_BLUE>;
+			label = "l:r4";
+			color = <LED_COLOR_ID_RED>;
 		};
 		ledl_g4: led@11 {
 			reg = <11>;
@@ -713,8 +713,8 @@
 		};
 		ledl_r4: led@12 {
 			reg = <12>;
-			label = "l:r4";
-			color = <LED_COLOR_ID_RED>;
+			label = "l:b4";
+			color = <LED_COLOR_ID_BLUE>;
 		};
 	};
 };


### PR DESCRIPTION
Red and Blue Led assignments were swapped.

Tested on latest Rocknix build for both the RP5 and RP Mini. 